### PR TITLE
Define our own hello app to use with getting started documentation

### DIFF
--- a/.github/workflows/hello-app.yml
+++ b/.github/workflows/hello-app.yml
@@ -1,0 +1,46 @@
+name: Create and publish hello-app
+
+# reference https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
+
+on:
+  push:
+    # only on push to main?
+    # branches: [main]
+  pull_request:
+    #TODO do not push for PR
+    branches: [main]
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/hello-app
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: hello-app
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/hello-app.yml
+++ b/.github/workflows/hello-app.yml
@@ -4,11 +4,8 @@ name: Create and publish hello-app
 
 on:
   push:
-    # only on push to main?
-    # branches: [main]
-  pull_request:
-    #TODO do not push for PR
     branches: [main]
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/hello-app

--- a/hello-app/Dockerfile
+++ b/hello-app/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.8-slim-buster
+
+ENV FLASK_APP=app
+
+WORKDIR /app
+COPY . /app
+
+RUN pip install Flask==0.12 
+CMD [ "python3", "-m" , "flask", "run", "--host=0.0.0.0", "--port=8080"]

--- a/hello-app/Dockerfile
+++ b/hello-app/Dockerfile
@@ -3,7 +3,8 @@ FROM python:3.8-slim-buster
 ENV FLASK_APP=app
 
 WORKDIR /app
-COPY . /app
 
 RUN pip install Flask==0.12 
+COPY . /app
+
 CMD [ "python3", "-m" , "flask", "run", "--host=0.0.0.0", "--port=8080"]

--- a/hello-app/README.md
+++ b/hello-app/README.md
@@ -14,4 +14,4 @@ This directory contains:
 
 This application is available as a Docker image:
 
-- `TODO`
+- `ghcr.io/run-x/opta-examples/hello-app:main`

--- a/hello-app/README.md
+++ b/hello-app/README.md
@@ -1,0 +1,17 @@
+# Hello Application example
+
+This example shows how to build and deploy a containerized python web server
+application using [Opta](https://github.com/run-x/opta).
+
+Visit https://docs.opta.dev/getting-started/
+to follow the tutorial and deploy this application.
+
+This directory contains:
+
+- `app.py` contains the HTTP server implementation. It responds to all HTTP
+  requests with a  `Hello, World!` response.
+- `Dockerfile` is used to build the Docker image for the application.
+
+This application is available as a Docker image:
+
+- `TODO`

--- a/hello-app/app.py
+++ b/hello-app/app.py
@@ -1,0 +1,6 @@
+from flask import Flask
+app = Flask(__name__)
+
+@app.route('/')
+def hello_world():
+    return "<p>Hello, World!</p>"


### PR DESCRIPTION
This small web app can be easily built and pushed by a user in the getting started guide.
This example is inspired from https://docs.docker.com/language/python/build-images/

Some notes:
- The workflow will build/push this image as github package, so it can be used in our documentation without requiring the user to build/push the image. (See how it looks [here](https://github.com/RemyDeWolf/opta-examples/pkgs/container/opta-examples%2Fhello-app)) This will also prevent our users hitting any [docker hub rate limit](https://docs.docker.com/docker-hub/download-rate-limit/).
- This image is 125MB. A similar image in go would be smaller (10MB), but would require pulling a go builder such as golang:1.17-alpine which is 313MB
- The documentation will be updated to use this app once this PR is approved.
