### PR TITLE
Fixed airflow for k1.22

### DIFF
--- a/airflow/airflow-aws.yaml
+++ b/airflow/airflow-aws.yaml
@@ -22,7 +22,7 @@ modules:
     repository: https://airflow.apache.org
     chart: airflow
     namespace: airflow
-    chart_version: 1.0.0
+    chart_version: 1.4.0
     create_namespace: true
     wait: false
     atomic: false
@@ -54,7 +54,7 @@ modules:
       ingress:
         enabled: true
         web:
-          path: ""
+          path: "/"
           host: "{module.dns.domain}"
           annotations:
             kubernetes.io/ingress.class: "nginx"


### PR DESCRIPTION
Upgraded chart version, tested on EKS 1.21 and on a Kubernetes 1.22 cluster.